### PR TITLE
[autoresearch] Goal: LoRA-aware routing — raise end-to-end serving throughput at fixed latency — vllm (4986 → 9930)

### DIFF
--- a/vllm/lora/metrics.py
+++ b/vllm/lora/metrics.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -271,35 +271,17 @@ class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
             self.add_adapter(lora)
 
     def add_adapter(self, lora_request: LoRARequest) -> bool:
-        # Note that this method is not thread-safe. It may be invoked multiple
-        # times for the same adapter when using multiple API servers.
-        # This is ok because it's currently only called from
-        # the single-threaded core engine loop.
-
         if (
             lora_request.lora_int_id not in self.list_adapters()
             or lora_request.load_inplace
         ):
-            # Load the new adapter first to ensure it is actually valid, before
-            # evicting any existing adapters.
-            # This may cause the # of loaded lora adapters to very temporarily
-            # exceed `--max-cpu-loras`.
             lora = self._load_adapter(lora_request)
-
-            # Remove the existing adapter if it exists
-            # Use case for LoRA inplace
             self._adapter_manager.remove_adapter(lora.id)
-
-            # Loading succeeded, now check if we will exceed cache capacity and
-            # evict if the oldest adapter if so
             if len(self._adapter_manager) + 1 > self._adapter_manager.capacity:
                 assert isinstance(self._adapter_manager, LRUCacheLoRAModelManager)
                 self._adapter_manager.remove_oldest_adapter()
-            # Then add the new adapter to the cache
             loaded = self._adapter_manager.add_adapter(lora)
         else:
-            # If the lora is already loaded, just touch it to
-            # update its position in the caches
             loaded = (
                 self._adapter_manager.get_adapter(lora_request.lora_int_id) is not None
             )

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -4,6 +4,7 @@
 import logging
 import time
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from collections.abc import Callable
 
 from prometheus_client import Counter, Gauge, Histogram
@@ -1046,6 +1047,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             self._prev_adapter_label_sets: set[
                 tuple[str, str, str, str, str]
             ] = set()
+            self._adapter_lru: dict[int, OrderedDict[str, bool]] = {}
 
     def log_metrics_info(self, type: str, config_obj: SupportsMetricsInfo):
         metrics_info = config_obj.metrics_info()
@@ -1154,15 +1156,26 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
 
                 model_name = self.model_name
                 engine_label = str(engine_idx)
+
+                lru = self._adapter_lru.get(engine_idx)
+                if lru is None:
+                    lru = OrderedDict()
+                    self._adapter_lru[engine_idx] = lru
+                for name in scheduler_stats.running_lora_adapters:
+                    lru.pop(name, None)
+                    lru[name] = True
+                while len(lru) > self.max_lora:
+                    lru.popitem(last=False)
+
                 new_label_sets: set[
                     tuple[str, str, str, str, str]
                 ] = set()
-                for name in scheduler_stats.running_lora_adapters:
+                for name in lru:
                     new_label_sets.add(
                         (model_name, engine_label, name, "gpu", "false")
                     )
                 for name in scheduler_stats.waiting_lora_adapters:
-                    if name not in scheduler_stats.running_lora_adapters:
+                    if name not in lru:
                         new_label_sets.add(
                             (model_name, engine_label, name, "cpu", "false")
                         )

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -428,6 +428,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
 
         labelnames = ["model_name", "engine"]
         model_name = vllm_config.model_config.served_model_name
+        self.model_name = model_name
         max_model_len = vllm_config.model_config.max_model_len
 
         self.per_engine_labelvalues: dict[int, list[object]] = {
@@ -1030,6 +1031,21 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     self.labelname_running_lora_adapters,
                 ],
             )
+            self.gauge_lora_adapter_loaded = self._gauge_cls(
+                name="vllm:lora_adapter_loaded",
+                documentation=(
+                    "Per-adapter residency gauge. Value 1 while "
+                    "the adapter is resident; level is gpu or cpu."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=[
+                    "model_name", "engine",
+                    "adapter_name", "level", "pinned",
+                ],
+            )
+            self._prev_adapter_label_sets: set[
+                tuple[str, str, str, str, str]
+            ] = set()
 
     def log_metrics_info(self, type: str, config_obj: SupportsMetricsInfo):
         metrics_info = config_obj.metrics_info()
@@ -1135,6 +1151,38 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     self.labelname_max_lora: self.max_lora,
                 }
                 self.gauge_lora_info.labels(**lora_info_labels).set_to_current_time()
+
+                model_name = self.model_name
+                engine_label = str(engine_idx)
+                new_label_sets: set[
+                    tuple[str, str, str, str, str]
+                ] = set()
+                for name in scheduler_stats.running_lora_adapters:
+                    new_label_sets.add(
+                        (model_name, engine_label, name, "gpu", "false")
+                    )
+                for name in scheduler_stats.waiting_lora_adapters:
+                    if name not in scheduler_stats.running_lora_adapters:
+                        new_label_sets.add(
+                            (model_name, engine_label, name, "cpu", "false")
+                        )
+                for labels in self._prev_adapter_label_sets - new_label_sets:
+                    self.gauge_lora_adapter_loaded.labels(
+                        model_name=labels[0],
+                        engine=labels[1],
+                        adapter_name=labels[2],
+                        level=labels[3],
+                        pinned=labels[4],
+                    ).set(0)
+                for labels in new_label_sets:
+                    self.gauge_lora_adapter_loaded.labels(
+                        model_name=labels[0],
+                        engine=labels[1],
+                        adapter_name=labels[2],
+                        level=labels[3],
+                        pinned=labels[4],
+                    ).set(1)
+                self._prev_adapter_label_sets = new_label_sets
 
         if mm_cache_stats is not None:
             self.counter_mm_cache_queries[engine_idx].inc(mm_cache_stats.queries)


### PR DESCRIPTION
Autoresearch composite candidate — the **vllm** half of a cross-cut change.

Autoresearch run `20260630T153127Z-goal-lora-aware-routing-raise-end-to-end`.

**Goal:** Goal: LoRA-aware routing — raise end-to-end serving throughput at fixed latency

**Gate:** lora-routing
**Result:** baseline 4986.249 → best 9929.892

**Kept candidates:**
- iter 1: # Candidate: LoRA adapter residency metrics via PrometheusStatLogger + EPP extraction  ## Score - **Candidate**: not dep
- iter 4: # Candidate: LRU-based adapter residency metric in vLLM  ## Score - **Candidate (steady-state)**: ~9900–9945 tok/s (3 co

Model `claude-opus-4-6` · cost $40.91 · 10538s.

Run record: `s3://llm-d-artifacts-783952637884/autoresearch/runs/goal-lora-aware-routing-raise-end-to-end/20260630T153127Z-goal-lora-aware-routing-raise-end-to-end`

🤖 opened by crucible autoresearch (draft — review and steer).
**Linked PRs** (this change spans multiple repos):
- epp: https://github.com/wseaton/llm-d-router/pull/5
