### PR TITLE
[autoresearch] Goal: LoRA-aware routing — route each request to a replica where its adapter is warm — vllm (0 → 1)

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -135,11 +135,14 @@ class AsyncLLM(EngineClient):
         self.input_processor = InputProcessor(self.vllm_config, renderer)
 
         # Converts EngineCoreOutputs --> RequestOutput.
+        lora_config = self.vllm_config.lora_config
         self.output_processor = OutputProcessor(
             renderer.tokenizer,
             log_stats=self.log_stats,
             stream_interval=self.vllm_config.scheduler_config.stream_interval,
             tracing_enabled=tracing_endpoint is not None,
+            max_loras=lora_config.max_loras if lora_config else 0,
+            max_cpu_loras=lora_config.max_cpu_loras if lora_config else 0,
         )
 
         # EngineCore (starts the engine in background process).

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -93,11 +93,14 @@ class LLMEngine:
         self.input_processor = InputProcessor(self.vllm_config, renderer)
 
         # Converts EngineCoreOutputs --> RequestOutput.
+        lora_config = self.vllm_config.lora_config
         self.output_processor = OutputProcessor(
             renderer.tokenizer,
             log_stats=self.log_stats,
             stream_interval=self.vllm_config.scheduler_config.stream_interval,
             tracing_enabled=tracing_endpoint is not None,
+            max_loras=lora_config.max_loras if lora_config else 0,
+            max_cpu_loras=lora_config.max_cpu_loras if lora_config else 0,
         )
 
         # EngineCore (gets EngineCoreRequests and gives EngineCoreOutputs)

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -424,6 +424,8 @@ class OutputProcessor:
         log_stats: bool,
         stream_interval: int = 1,
         tracing_enabled: bool = False,
+        max_loras: int = 0,
+        max_cpu_loras: int = 0,
     ):
         self.log_stats = log_stats
         self.tokenizer = tokenizer
@@ -431,7 +433,11 @@ class OutputProcessor:
         self.request_states: dict[str, RequestState] = {}
         self.parent_requests: dict[str, ParentRequest] = {}
         self.external_req_ids: defaultdict[str, list[str]] = defaultdict(list)
-        self.lora_states = LoRARequestStates(log_stats)
+        self.lora_states = LoRARequestStates(
+            log_stats,
+            max_gpu_loras=max_loras,
+            max_cpu_loras=max_cpu_loras,
+        )
         self.tracing_enabled = tracing_enabled
 
     def get_num_unfinished_requests(self):

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1010,6 +1010,10 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         # TODO: This metric might be incorrect in case of using multiple
         # api_server counts which uses prometheus mp.
         self.gauge_lora_info: Gauge | None = None
+        self.gauge_lora_adapter_loaded: Gauge | None = None
+        self.gauge_num_gpu_loaded: Gauge | None = None
+        self.gauge_num_cpu_loaded: Gauge | None = None
+        self._prev_adapter_labels: set[tuple[str, str, str]] = set()
         if vllm_config.lora_config is not None:
             if len(self.engine_indexes) > 1:
                 logger.warning(
@@ -1029,6 +1033,34 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     self.labelname_waiting_lora_adapters,
                     self.labelname_running_lora_adapters,
                 ],
+            )
+            self.gauge_lora_adapter_loaded = self._gauge_cls(
+                name="vllm:lora_adapter_loaded",
+                documentation=(
+                    "Per-adapter residency state. Value is 1 for each "
+                    "loaded adapter."
+                ),
+                multiprocess_mode="max",
+                labelnames=[
+                    "adapter_name",
+                    "level",
+                    "pinned",
+                ],
+            )
+            self.gauge_num_gpu_loaded = self._gauge_cls(
+                name="vllm:num_gpu_loaded_lora_adapters",
+                documentation=(
+                    "Number of LoRA adapters currently loaded on GPU."
+                ),
+                multiprocess_mode="max",
+            )
+            self.gauge_num_cpu_loaded = self._gauge_cls(
+                name="vllm:num_cpu_loaded_lora_adapters",
+                documentation=(
+                    "Number of LoRA adapters currently cached in CPU "
+                    "memory."
+                ),
+                multiprocess_mode="max",
             )
 
     def log_metrics_info(self, type: str, config_obj: SupportsMetricsInfo):
@@ -1135,6 +1167,31 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     self.labelname_max_lora: self.max_lora,
                 }
                 self.gauge_lora_info.labels(**lora_info_labels).set_to_current_time()
+
+            if self.gauge_lora_adapter_loaded is not None:
+                current_labels: set[tuple[str, str, str]] = set()
+                gpu_count = 0
+                cpu_count = 0
+                for name, level, pinned in scheduler_stats.loaded_adapters:
+                    pinned_str = str(pinned).lower()
+                    label = (name, level, pinned_str)
+                    current_labels.add(label)
+                    self.gauge_lora_adapter_loaded.labels(
+                        adapter_name=name,
+                        level=level,
+                        pinned=pinned_str,
+                    ).set(1)
+                    if level == "gpu":
+                        gpu_count += 1
+                    else:
+                        cpu_count += 1
+                for stale in self._prev_adapter_labels - current_labels:
+                    self.gauge_lora_adapter_loaded.remove(*stale)
+                self._prev_adapter_labels = current_labels
+                assert self.gauge_num_gpu_loaded is not None
+                assert self.gauge_num_cpu_loaded is not None
+                self.gauge_num_gpu_loaded.set(gpu_count)
+                self.gauge_num_cpu_loaded.set(cpu_count)
 
         if mm_cache_stats is not None:
             self.counter_mm_cache_queries[engine_idx].inc(mm_cache_stats.queries)

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import time
-from collections import defaultdict, deque
+from collections import OrderedDict, defaultdict, deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -192,6 +192,8 @@ class SchedulerStats:
 
     waiting_lora_adapters: dict[str, int] = field(default_factory=dict)
     running_lora_adapters: dict[str, int] = field(default_factory=dict)
+
+    loaded_adapters: list[tuple[str, str, bool]] = field(default_factory=list)
 
     cudagraph_stats: CUDAGraphStat | None = None
 
@@ -507,9 +509,32 @@ class LoRAStats:
 class LoRARequestStates:
     """A per-LoRA count of running and waiting requests."""
 
-    def __init__(self, log_stats: bool = False):
+    def __init__(
+        self,
+        log_stats: bool = False,
+        max_gpu_loras: int = 0,
+        max_cpu_loras: int = 0,
+    ):
         self.log_stats = log_stats
         self.requests: defaultdict[str, LoRAStats] = defaultdict(LoRAStats)
+        self._max_gpu = max_gpu_loras
+        self._max_cpu = max_cpu_loras
+        self._gpu_adapters: OrderedDict[str, None] = OrderedDict()
+        self._cpu_adapters: OrderedDict[str, None] = OrderedDict()
+
+    def _touch_adapter(self, lora_name: str) -> None:
+        if not self._max_gpu:
+            return
+        if lora_name in self._gpu_adapters:
+            self._gpu_adapters.move_to_end(lora_name)
+            return
+        self._cpu_adapters.pop(lora_name, None)
+        while len(self._gpu_adapters) >= self._max_gpu:
+            evicted, _ = self._gpu_adapters.popitem(last=False)
+            self._cpu_adapters[evicted] = None
+            while self._max_cpu and len(self._cpu_adapters) > self._max_cpu:
+                self._cpu_adapters.popitem(last=False)
+        self._gpu_adapters[lora_name] = None
 
     def _request_update(
         self, req_id: str, lora_name: str | None, waiting: bool, running: bool
@@ -521,6 +546,9 @@ class LoRARequestStates:
         lora_stats.update(req_id, waiting, running)
         if lora_stats.empty:
             del self.requests[lora_name]
+
+        if running:
+            self._touch_adapter(lora_name)
 
     def request_waiting(self, req_id: str, lora_name: str | None):
         self._request_update(req_id, lora_name, waiting=True, running=False)
@@ -537,3 +565,7 @@ class LoRARequestStates:
         for lora_name, stats in self.requests.items():
             scheduler_stats.waiting_lora_adapters[lora_name] = len(stats.waiting)
             scheduler_stats.running_lora_adapters[lora_name] = len(stats.running)
+        for name in self._gpu_adapters:
+            scheduler_stats.loaded_adapters.append((name, "gpu", False))
+        for name in self._cpu_adapters:
+            scheduler_stats.loaded_adapters.append((name, "cpu", False))


### PR DESCRIPTION
Autoresearch composite candidate — the **vllm** half of a cross-cut change.

Autoresearch run `20260701T000610Z-goal-lora-aware-routing-route-each-reque`.

**Goal:** Goal: LoRA-aware routing — route each request to a replica where its adapter is warm

**Gate:** lora-routing
**Result:** baseline 0.500 → best 1.000

**Kept candidates:**
- iter 1: # Candidate: LoRA-aware routing — adapter residency metrics + EPP extraction  ## Changes  ### vLLM — per-adapter residen

Model `claude-opus-4-6` · cost $12.29 · 1345s.

Run record: `s3://llm-d-artifacts-783952637884/autoresearch/runs/goal-lora-aware-routing-route-each-reque/20260701T000610Z-goal-lora-aware-routing-route-each-reque`

🤖 opened by crucible autoresearch (draft — review and steer).
