### PR TITLE
[autoresearch] generalize fused_a_gemm for GLM-5.2 (8.860 → 8.533 ms TPOT)

### DIFF
--- a/OPERATOR_NOTE.md
+++ b/OPERATOR_NOTE.md
@@ -1,0 +1,12 @@
+# OPERATOR NOTE — proven-port era; anchor to beat is 8.571 ms
+
+The shape-general fused A-GEMM port has now passed the full ladder twice:
+GSM8K 0.94-0.965, TPOT 8.613 then 8.571 ms (117 tok/s). The recipe: generalized kernel
+body, weight.T column-major views, kill-switch env var; builds must be full when csrc
+changes (the gate handles this — diff vs pinned baseline).
+
+This run has PREFLIGHT: env problems refuse the run before your first turn, and the
+stock baseline TPOT is measured for you — decide is anchored now. Declare your
+kill-switch env name via VLLM_GLM_TOGGLE so the ab-toggle rung stops skipping.
+
+Fetch full logs via broker fetch_log before diagnosing. Delete this file after reading.

--- a/cross-trace/code_gen_config_plan_1.json
+++ b/cross-trace/code_gen_config_plan_1.json
@@ -1,0 +1,23 @@
+{
+    "cross_trace_config": "/sandbox/vllm/cross-trace/cross_trace_config.json",
+    "improvement_id": 1,
+    "source_code_dir": "/sandbox/vllm",
+    "output_dir": "/sandbox/vllm/codegen-out",
+    "num_code_port_plan_iterations": 3,
+    "num_test_plan_iterations": 3,
+    "num_code_gen_iterations": 3,
+    "num_runtime_iterations": 10,
+    "gpu_wait_timeout_minutes": 30,
+    "use_smaller_model_for_runtime": false,
+    "disable_new_feature_for_runtime": false,
+    "additional_benchmark_configs": [],
+    "runtime_backend": "delegated",
+    "disallowed_modules": ["sglang*"],
+    "code_port_plan_skip_review": false,
+    "test_plan_skip_review": false,
+    "code_gen_skip_review": false,
+    "generate_pr_commands": false,
+    "pr_base_branch": "main",
+    "pr_remote": "origin",
+    "thinking-mode": "deep"
+}

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -279,6 +279,7 @@ if TYPE_CHECKING:
     VLLM_WEIGHT_OFFLOADING_DISABLE_UVA: bool = False
     VLLM_WSL2_ENABLE_PIN_MEMORY: bool = False
     VLLM_DISABLE_LOG_LOGO: bool = False
+    VLLM_DISABLE_FUSED_A_GEMM_JIT: bool = False
     VLLM_LORA_DISABLE_PDL: bool = False
     VLLM_ENABLE_CUDA_COMPATIBILITY: bool = False
     VLLM_CUDA_COMPATIBILITY_PATH: str | None = None
@@ -1951,6 +1952,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Disable logging of vLLM logo at server startup time.
     "VLLM_DISABLE_LOG_LOGO": lambda: bool(int(os.getenv("VLLM_DISABLE_LOG_LOGO", "0"))),
+    # Disable JIT-compiled fused_a_gemm kernel for MLA projections.
+    "VLLM_DISABLE_FUSED_A_GEMM_JIT": lambda: bool(
+        int(os.getenv("VLLM_DISABLE_FUSED_A_GEMM_JIT", "0"))
+    ),
     # Disable PDL for LoRA, as enabling PDL with LoRA on SM100 causes
     # Triton compilation to fail.
     "VLLM_LORA_DISABLE_PDL": lambda: bool(int(os.getenv("VLLM_LORA_DISABLE_PDL", "0"))),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -279,7 +279,7 @@ if TYPE_CHECKING:
     VLLM_WEIGHT_OFFLOADING_DISABLE_UVA: bool = False
     VLLM_WSL2_ENABLE_PIN_MEMORY: bool = False
     VLLM_DISABLE_LOG_LOGO: bool = False
-    VLLM_DISABLE_FUSED_A_GEMM_JIT: bool = False
+    VLLM_GLM_TOGGLE: bool = False
     VLLM_LORA_DISABLE_PDL: bool = False
     VLLM_ENABLE_CUDA_COMPATIBILITY: bool = False
     VLLM_CUDA_COMPATIBILITY_PATH: str | None = None
@@ -1953,8 +1953,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disable logging of vLLM logo at server startup time.
     "VLLM_DISABLE_LOG_LOGO": lambda: bool(int(os.getenv("VLLM_DISABLE_LOG_LOGO", "0"))),
     # Disable JIT-compiled fused_a_gemm kernel for MLA projections.
-    "VLLM_DISABLE_FUSED_A_GEMM_JIT": lambda: bool(
-        int(os.getenv("VLLM_DISABLE_FUSED_A_GEMM_JIT", "0"))
+    "VLLM_GLM_TOGGLE": lambda: bool(
+        int(os.getenv("VLLM_GLM_TOGGLE", "0"))
     ),
     # Disable PDL for LoRA, as enabling PDL with LoRA on SM100 causes
     # Triton compilation to fail.

--- a/vllm/model_executor/kernels/fused_a_gemm/__init__.py
+++ b/vllm/model_executor/kernels/fused_a_gemm/__init__.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""JIT-compiled fused_a_gemm kernel for MLA projections.
+
+Supports generalized shapes via per-(hd_in, hd_out) JIT compilation.
+The kernel is optimized for num_tokens in [1, 16] with BF16 I/O and
+FP32 accumulation. Falls back to F.linear for num_tokens > 16.
+
+Kill-switch: set VLLM_DISABLE_FUSED_A_GEMM_JIT=1 to disable.
+"""
+
+import functools
+import logging
+import os
+import pathlib
+
+import torch
+from torch.utils.cpp_extension import load
+
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
+
+logger = logging.getLogger(__name__)
+
+_FUSED_A_GEMM_JIT_DISABLED = bool(
+    int(os.getenv("VLLM_DISABLE_FUSED_A_GEMM_JIT", "0"))
+)
+
+if _FUSED_A_GEMM_JIT_DISABLED:
+    logger.info("Fused A GEMM JIT kernel is DISABLED (env override)")
+else:
+    logger.info("Fused A GEMM JIT kernel is ENABLED")
+
+_CUDA_DIR = pathlib.Path(__file__).parent
+
+# Explicit allowlists — every entry must have a verified CUDA template
+# instantiation via pick_tile_m and static_asserts (KB Entry 33).
+_SUPPORTED_QKV_A_SHAPES: set[tuple[int, int]] = {
+    (2112, 7168),  # DeepSeek-V3 QKV-A (tile_m=16)
+    (2624, 6144),  # GLM-5.2 QKV-A at TP=4 (tile_m=32)
+}
+
+_SUPPORTED_Q_B_SHAPES: set[tuple[int, int]] = {
+    (4096, 2048),  # GLM-5.2 Q-B at TP=4 (tile_m=32)
+}
+
+_ALL_SUPPORTED_SHAPES = _SUPPORTED_QKV_A_SHAPES | _SUPPORTED_Q_B_SHAPES
+
+
+@functools.lru_cache(maxsize=None)
+def _load_jit_module(hd_in: int, hd_out: int):
+    """JIT compile the fused_a_gemm kernel for specific (hd_in, hd_out).
+
+    Each (hd_in, hd_out) pair is compiled once and cached via lru_cache.
+    """
+    module = load(
+        name=f"fused_a_gemm_{hd_in}_{hd_out}",
+        sources=[str(_CUDA_DIR / "dsv3_fused_a_gemm_wrapper.cu")],
+        extra_include_paths=[str(_CUDA_DIR)],
+        extra_cuda_cflags=[
+            f"-DFUSED_A_GEMM_HD_IN={hd_in}",
+            f"-DFUSED_A_GEMM_HD_OUT={hd_out}",
+            "-gencode", "arch=compute_90a,code=sm_90a",
+            "-gencode", "arch=compute_100a,code=sm_100a",
+            "--expt-relaxed-constexpr",
+            "-O3",
+        ],
+        verbose=False,
+    )
+    logger.info(
+        "JIT compiled fused_a_gemm kernel for hd_in=%d, hd_out=%d",
+        hd_in, hd_out,
+    )
+    return module
+
+
+def _fused_a_gemm_jit_impl(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    num_tokens = input_.shape[0]
+    if (
+        not _FUSED_A_GEMM_JIT_DISABLED
+        and 0 < num_tokens <= 16
+    ):
+        hd_in = input_.shape[1]
+        hd_out = weight.shape[0]
+        module = _load_jit_module(hd_in, hd_out)
+        return module.fused_a_gemm_forward(input_, weight.T)
+    else:
+        return torch.nn.functional.linear(input_, weight)
+
+
+def _fused_a_gemm_jit_fake(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    return input_.new_empty(input_.shape[0], weight.shape[0])
+
+
+direct_register_custom_op(
+    op_name="fused_a_gemm_jit",
+    op_func=_fused_a_gemm_jit_impl,
+    mutates_args=[],
+    fake_impl=_fused_a_gemm_jit_fake,
+)
+
+
+def is_fused_a_gemm_eligible(weight: torch.Tensor) -> bool:
+    """Check if a weight tensor is eligible for fused_a_gemm JIT.
+
+    Uses explicit shape allowlists per KB Entry 33.
+    """
+    if _FUSED_A_GEMM_JIT_DISABLED:
+        return False
+    shape = (weight.shape[0], weight.shape[1])
+    return (
+        weight.dtype == torch.bfloat16
+        and shape in _ALL_SUPPORTED_SHAPES
+        and current_platform.is_cuda()
+        and (
+            current_platform.is_device_capability(90)
+            or current_platform.is_device_capability_family(100)
+        )
+    )

--- a/vllm/model_executor/kernels/fused_a_gemm/__init__.py
+++ b/vllm/model_executor/kernels/fused_a_gemm/__init__.py
@@ -6,7 +6,7 @@ Supports generalized shapes via per-(hd_in, hd_out) JIT compilation.
 The kernel is optimized for num_tokens in [1, 16] with BF16 I/O and
 FP32 accumulation. Falls back to F.linear for num_tokens > 16.
 
-Kill-switch: set VLLM_DISABLE_FUSED_A_GEMM_JIT=1 to disable.
+Kill-switch: set VLLM_GLM_TOGGLE=1 to disable.
 """
 
 import functools
@@ -23,7 +23,7 @@ from vllm.utils.torch_utils import direct_register_custom_op
 logger = logging.getLogger(__name__)
 
 _FUSED_A_GEMM_JIT_DISABLED = bool(
-    int(os.getenv("VLLM_DISABLE_FUSED_A_GEMM_JIT", "0"))
+    int(os.getenv("VLLM_GLM_TOGGLE", "0"))
 )
 
 if _FUSED_A_GEMM_JIT_DISABLED:

--- a/vllm/model_executor/kernels/fused_a_gemm/dsv3_fused_a_gemm.cuh
+++ b/vllm/model_executor/kernels/fused_a_gemm/dsv3_fused_a_gemm.cuh
@@ -1,0 +1,623 @@
+/*
+ * Adapted from
+ * https://github.com/NVIDIA/TensorRT-LLM/blob/619709fc33bd5dc268f19d6a741fe7ed51c0f8f5/cpp/tensorrt_llm/kernels/dsv3MinLatencyKernels/dsv3FusedAGemm.cu
+ *
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2021, NAVER Corp.  Authored by CLOVA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <utility>
+
+#include <cstdlib>
+#include <mutex>
+
+namespace {
+
+using bf16_t = __nv_bfloat16;
+
+inline bool getEnvEnablePDL() {
+  static std::once_flag flag;
+  static bool enablePDL = false;
+  std::call_once(flag, [&]() {
+    char const* env = std::getenv("TRTLLM_ENABLE_PDL");
+    enablePDL = env && env[0] == '1' && env[1] == '\0';
+  });
+  return enablePDL;
+}
+
+__device__ void hmma_16_8_16_f32acc_bf16ab(
+    float (&d_reg)[4], const bf16_t (&a_reg)[8], const bf16_t (&b_reg)[4], float const (&c_reg)[4]) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  uint32_t a0 = *reinterpret_cast<uint32_t const*>(a_reg + 0);
+  uint32_t a1 = *reinterpret_cast<uint32_t const*>(a_reg + 2);
+  uint32_t a2 = *reinterpret_cast<uint32_t const*>(a_reg + 4);
+  uint32_t a3 = *reinterpret_cast<uint32_t const*>(a_reg + 6);
+  uint32_t b0 = *reinterpret_cast<uint32_t const*>(b_reg + 0);
+  uint32_t b1 = *reinterpret_cast<uint32_t const*>(b_reg + 2);
+  asm volatile(
+      "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+      "{%0,  %1,  %2,  %3},"
+      "{%4,  %5,  %6,  %7},"
+      "{%8,  %9},"
+      "{%10, %11, %12, %13};\n"
+      : "=f"(d_reg[0]), "=f"(d_reg[1]), "=f"(d_reg[2]), "=f"(d_reg[3])
+      : "r"(a0),
+        "r"(a1),
+        "r"(a2),
+        "r"(a3),
+        "r"(b0),
+        "r"(b1),
+        "f"(d_reg[0]),
+        "f"(d_reg[1]),
+        "f"(d_reg[2]),
+        "f"(d_reg[3]));
+#endif
+}
+
+extern "C" {
+__device__ uint32_t __nvvm_get_smem_pointer(void*);
+}
+
+__device__ void ldgsts_128(void const* gPtr, void* sPtr, uint32_t pred) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  if (pred) {
+    uint32_t smemPtrAsUint32 = __nvvm_get_smem_pointer(sPtr);
+    asm volatile("cp.async.cg.shared.global.L2::128B [%0], [%1], %2;\n" ::"r"(smemPtrAsUint32), "l"(gPtr), "n"(16));
+  }
+#endif
+}
+
+__device__ void ldsm_x4(void* smem_ptr, uint32_t* reg_ptr) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+               : "=r"(reg_ptr[0]), "=r"(reg_ptr[1]), "=r"(reg_ptr[2]), "=r"(reg_ptr[3])
+               : "r"(__nvvm_get_smem_pointer(smem_ptr)));
+#endif
+}
+
+template <class Type>
+__device__ int apply_swizzle_343_on_elem_row_col(int row_idx_, int col_idx_) {
+  uint32_t row_idx = *reinterpret_cast<uint32_t*>(&row_idx_);
+  uint32_t col_idx = *reinterpret_cast<uint32_t*>(&col_idx_);
+  row_idx = row_idx % 8;
+  row_idx = row_idx * (16 / sizeof(Type));
+  col_idx = col_idx ^ row_idx;
+  return *reinterpret_cast<int*>(&col_idx);
+}
+
+__device__ void initialize_barrier(uint64_t* smem_barrier, int thread_count = 1) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+  asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" ::"r"(smem_int_ptr), "r"(thread_count));
+#endif
+}
+
+__device__ void wait_barrier(uint64_t* smem_barrier, int phase_bit) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+  asm volatile(
+      "{\n"
+      ".reg .pred                P1;\n"
+      "LAB_WAIT:\n"
+      "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1;\n"
+      "@P1                       bra DONE;\n"
+      "bra                   LAB_WAIT;\n"
+      "DONE:\n"
+      "}\n" ::"r"(smem_int_ptr),
+      "r"(phase_bit));
+#endif
+}
+
+__device__ bool try_wait_barrier(uint64_t* smem_ptr, int phase_bit) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  uint32_t wait_complete;
+  uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_ptr);
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1; \n\t"
+      "mbarrier.try_wait.parity.shared::cta.b64 P1, [%1], %2; \n\t"
+      "selp.b32 %0, 1, 0, P1; \n\t"
+      "}"
+      : "=r"(wait_complete)
+      : "r"(smem_int_ptr), "r"(phase_bit));
+  return static_cast<bool>(wait_complete);
+#endif
+  return false;
+}
+
+__device__ void arrive_barrier(uint64_t* smem_barrier) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+  asm volatile(
+      "{\n"
+      ".reg .b64 state; \n"
+      "mbarrier.arrive.shared::cta.b64   state, [%0];\n"
+      "}\n" ::"r"(smem_int_ptr));
+#endif
+}
+
+__device__ void ldgsts_arrive(uint64_t* smem_barrier) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+  asm volatile("cp.async.mbarrier.arrive.noinc.shared.b64 [%0];" : : "r"(smem_int_ptr));
+#endif
+}
+
+template <int gemm_k, int tile_m, int tile_k, int stage_cnt>
+struct GmemLoaderA {
+  static constexpr int elem_bytes = 2;
+  static constexpr int vec_bytes = 16;
+  static constexpr int vec_elems = vec_bytes / elem_bytes;
+  static constexpr int thread_cnt = 64;
+  static_assert((tile_m * tile_k) % (vec_elems * thread_cnt) == 0);
+  static constexpr int a_inst_cnt_per_iter = (tile_m * tile_k) / (vec_elems * thread_cnt);
+  static_assert(gemm_k % tile_k == 0);
+  static constexpr int k_iter_cnt = gemm_k / tile_k;
+
+  static constexpr int mma_warp_cnt = 4;
+  static constexpr int per_mma_warp_k = tile_k / mma_warp_cnt;
+  static constexpr int k_each_chunk = gemm_k / mma_warp_cnt;
+
+ private:
+  __device__ int k_project(int tile_k_idx) {
+    return (tile_k_idx / per_mma_warp_k * k_each_chunk) + (tile_k_idx % per_mma_warp_k);
+  }
+
+ public:
+  __device__ GmemLoaderA(bf16_t const* gmem_a_local_, bf16_t* smem_a_, uint64_t* smem_barrier_)
+      : gmem_a(gmem_a_local_), smem_a(smem_a_), smem_barrier(smem_barrier_), local_tid(threadIdx.x % thread_cnt) {}
+
+  __device__ void prepare() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#pragma unroll
+    for (int i = 0; i < a_inst_cnt_per_iter; i++) {
+      int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+      int m_idx = linear_idx / tile_k;
+      int k_idx = linear_idx % tile_k;
+      k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(m_idx, k_idx);
+      a_smem_offsets[i] = m_idx * tile_k + k_idx;
+    }
+#endif
+  }
+
+  __device__ void issue_mainloop() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#pragma unroll 1
+    for (int loop_idx = 0; loop_idx < k_iter_cnt; loop_idx++) {
+      if (need_wait) {
+        wait_barrier(smem_barrier + 1 + stage_idx * 2, phase_bit);
+      }
+      int next_stage_idx = stage_idx + 1;
+      int next_phase_bit = next_stage_idx == stage_cnt ? phase_bit ^ 1 : phase_bit;
+      next_stage_idx = next_stage_idx == stage_cnt ? 0 : next_stage_idx;
+      if (loop_idx != k_iter_cnt - 1) {
+        need_wait = !try_wait_barrier(smem_barrier + 1 + next_stage_idx * 2, next_phase_bit);
+      }
+
+#pragma unroll
+      for (int i = 0; i < a_inst_cnt_per_iter; i++) {
+        int smem_offset = a_smem_offsets[i];
+        bf16_t* smem_ptr_this_iter = smem_a + stage_idx * tile_m * tile_k + smem_offset;
+        int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+        int m_idx = linear_idx / tile_k;
+        int k_idx = linear_idx % tile_k;
+        int gmem_offset = m_idx * gemm_k + k_project(k_idx);
+        bf16_t const* gmem_ptr_this_iter = gmem_a + gmem_offset;
+        ldgsts_128(gmem_ptr_this_iter, smem_ptr_this_iter, true);
+      }
+      ldgsts_arrive(smem_barrier + stage_idx * 2);
+
+      stage_idx = next_stage_idx;
+      phase_bit = next_phase_bit;
+      gmem_a += per_mma_warp_k;
+    }
+#endif
+  }
+
+  bf16_t const* gmem_a;
+  bf16_t* smem_a;
+  uint64_t* smem_barrier;
+  int local_tid;
+  int stage_idx = 0;
+  int phase_bit = 1;
+  bool need_wait = true;
+
+  int a_smem_offsets[a_inst_cnt_per_iter];
+};
+
+template <int gemm_k, int tile_n, int tile_k, int stage_cnt>
+struct GmemLoaderB {
+  static constexpr int elem_bytes = 2;
+  static constexpr int vec_bytes = 16;
+  static constexpr int vec_elems = vec_bytes / elem_bytes;
+  static constexpr int thread_cnt = 64;
+  static_assert((tile_n * tile_k) % (vec_elems * thread_cnt) == 0);
+  static constexpr int b_inst_cnt_per_iter = (tile_n * tile_k) / (vec_elems * thread_cnt);
+  static_assert(gemm_k % tile_k == 0);
+  static constexpr int k_iter_cnt = gemm_k / tile_k;
+
+  static constexpr int mma_warp_cnt = 4;
+  static constexpr int per_mma_warp_k = tile_k / mma_warp_cnt;
+  static constexpr int k_each_chunk = gemm_k / mma_warp_cnt;
+
+ private:
+  __device__ int k_project(int tile_k_idx) {
+    return (tile_k_idx / per_mma_warp_k * k_each_chunk) + (tile_k_idx % per_mma_warp_k);
+  }
+
+ public:
+  __device__ GmemLoaderB(bf16_t const* gmem_b_local_, bf16_t* smem_b_, uint64_t* smem_barrier_, int gemm_n_)
+      : gmem_b(gmem_b_local_),
+        smem_b(smem_b_),
+        smem_barrier(smem_barrier_),
+        gemm_n(gemm_n_),
+        local_tid(threadIdx.x % thread_cnt) {}
+
+  __device__ void prepare() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#pragma unroll
+    for (int i = 0; i < b_inst_cnt_per_iter; i++) {
+      int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+      int n_idx = linear_idx / tile_k;
+      int k_idx = linear_idx % tile_k;
+      k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(n_idx, k_idx);
+      b_smem_offsets[i] = n_idx * tile_k + k_idx;
+      preds[i] = n_idx < gemm_n;
+    }
+#endif
+  }
+
+  __device__ void issue_mainloop() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+    cudaGridDependencySynchronize();
+#pragma unroll 1
+    for (int loop_idx = 0; loop_idx < k_iter_cnt; loop_idx++) {
+      if (need_wait) {
+        wait_barrier(smem_barrier + 1 + stage_idx * 2, phase_bit);
+      }
+      int next_stage_idx = stage_idx + 1;
+      int next_phase_bit = next_stage_idx == stage_cnt ? phase_bit ^ 1 : phase_bit;
+      next_stage_idx = next_stage_idx == stage_cnt ? 0 : next_stage_idx;
+      if (loop_idx != k_iter_cnt - 1) {
+        need_wait = !try_wait_barrier(smem_barrier + 1 + next_stage_idx * 2, next_phase_bit);
+      }
+#pragma unroll
+      for (int i = 0; i < b_inst_cnt_per_iter; i++) {
+        int smem_offset = b_smem_offsets[i];
+        bf16_t* smem_ptr_this_iter = smem_b + stage_idx * tile_n * tile_k + smem_offset;
+        int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+        int n_idx = linear_idx / tile_k;
+        int k_idx = linear_idx % tile_k;
+        int gmem_offset = n_idx * gemm_k + k_project(k_idx);
+        bf16_t const* gmem_ptr_this_iter = gmem_b + gmem_offset;
+        ldgsts_128(gmem_ptr_this_iter, smem_ptr_this_iter, preds[i]);
+      }
+      ldgsts_arrive(smem_barrier + stage_idx * 2);
+
+      stage_idx = next_stage_idx;
+      phase_bit = next_phase_bit;
+      gmem_b += per_mma_warp_k;
+    }
+#endif
+  }
+
+  bf16_t const* gmem_b;
+  bf16_t* smem_b;
+  uint64_t* smem_barrier;
+  int gemm_n;
+  int local_tid;
+  int stage_idx = 0;
+  int phase_bit = 1;
+  bool need_wait = true;
+
+  int b_smem_offsets[b_inst_cnt_per_iter];
+  uint32_t preds[b_inst_cnt_per_iter];
+};
+
+template <int gemm_m, int gemm_k, int tile_m, int tile_n, int tile_k, int stage_cnt>
+struct MmaComputer {
+  static constexpr int elem_bytes = 2;
+  static constexpr int thread_cnt = 128;
+  static_assert(gemm_k % tile_k == 0);
+  static_assert(tile_k % (thread_cnt / 32) == 0);
+  static constexpr int per_warp_tile_k = tile_k / (thread_cnt / 32);
+  static constexpr int k_iter_cnt = gemm_k / tile_k;
+  static constexpr int k_phase_cnt = per_warp_tile_k / 16;
+  static constexpr int m_iter_cnt = (tile_m + 15) / 16;
+  static constexpr int n_iter_cnt = (tile_n + 7) / 8;
+  static_assert(m_iter_cnt == 1 || m_iter_cnt == 2);
+  static_assert(n_iter_cnt == 1 || n_iter_cnt == 2);
+
+  __device__ MmaComputer(
+      bf16_t* gmem_c_local_, bf16_t* smem_a_, bf16_t* smem_b_, uint64_t* smem_barrier_, int warp_idx_, int gemm_n_)
+      : gmem_c(gmem_c_local_),
+        smem_a(smem_a_),
+        smem_b(smem_b_),
+        smem_barrier(smem_barrier_),
+        warp_idx(warp_idx_ - (thread_cnt / 32)),
+        gemm_n(gemm_n_) {}
+
+ private:
+  __device__ constexpr int internal_b_atom_func(int tid) {
+    if constexpr (tile_n < 8) {
+      return (tid % tile_n) + ((tid % 8) / tile_n * 0) + tid / 8 * 8 * tile_n;
+    } else {
+      return (tid % 8) + ((tid % 32) / 8 * (tile_n * 8));
+    }
+  }
+
+ public:
+  __device__ void prepare() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#pragma unroll
+    for (int m = 0; m < m_iter_cnt; m++) {
+#pragma unroll
+      for (int i = 0; i < k_phase_cnt; i++) {
+        int linear_idx = (lane_idx % 16) + (lane_idx / 16) * 128 + i * 256;
+        int m_idx = linear_idx % 16 + m * 16;
+        int k_idx = linear_idx / 16 + warp_k_offset_in_tile_k;
+        k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(m_idx, k_idx);
+        a_smem_offsets[m][i] = m_idx * tile_k + k_idx;
+      }
+    }
+#pragma unroll
+    for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++) {
+#pragma unroll
+      for (int i = 0; i < k_phase_cnt; i += 2) {
+        int linear_idx = internal_b_atom_func(lane_idx) + i * tile_n * 16 + n_iter_idx * 8;
+        int n_idx = linear_idx % tile_n;
+        int k_idx = linear_idx / tile_n + warp_k_offset_in_tile_k;
+        k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(n_idx, k_idx);
+        b_smem_offsets[n_iter_idx][i] = n_idx * tile_k + k_idx;
+      }
+    }
+#endif
+  }
+
+  __device__ void issue_mainloop() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#pragma unroll 1
+    for (int loop_idx = 0; loop_idx < k_iter_cnt; loop_idx++) {
+      wait_barrier(smem_barrier + 0 + stage_idx * 2, phase_bit);
+
+#pragma unroll
+      for (int m = 0; m < m_iter_cnt; m++) {
+#pragma unroll
+        for (int i = 0; i < k_phase_cnt; i++) {
+          int smem_offset = a_smem_offsets[m][i];
+          bf16_t* smem_ptr_this_iter = smem_a + stage_idx * tile_m * tile_k + smem_offset;
+          ldsm_x4(smem_ptr_this_iter, reinterpret_cast<uint32_t*>(a_reg[m][i]));
+        }
+      }
+
+#pragma unroll
+      for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++) {
+#pragma unroll
+        for (int i = 0; i < k_phase_cnt; i += 2) {
+          int smem_offset = b_smem_offsets[n_iter_idx][i];
+          bf16_t* smem_ptr_this_iter = smem_b + stage_idx * tile_n * tile_k + smem_offset;
+          ldsm_x4(smem_ptr_this_iter, reinterpret_cast<uint32_t*>(b_reg[n_iter_idx][i]));
+        }
+      }
+
+#pragma unroll
+      for (int k_iter_idx = 0; k_iter_idx < k_phase_cnt; k_iter_idx++) {
+#pragma unroll
+        for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++) {
+#pragma unroll
+          for (int m = 0; m < m_iter_cnt; m++) {
+            hmma_16_8_16_f32acc_bf16ab(
+                acc_reg[m][n_iter_idx], a_reg[m][k_iter_idx], b_reg[n_iter_idx][k_iter_idx], acc_reg[m][n_iter_idx]);
+          }
+        }
+      }
+      ::arrive_barrier(smem_barrier + 1 + stage_idx * 2);
+      stage_idx += 1;
+      phase_bit = stage_idx == stage_cnt ? phase_bit ^ 1 : phase_bit;
+      stage_idx = stage_idx == stage_cnt ? 0 : stage_idx;
+    }
+#endif
+  }
+
+  __device__ void epi() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+    asm volatile("bar.sync %0, %1;" : : "r"(1), "r"(thread_cnt));
+    constexpr int thread_m = 2 * m_iter_cnt;
+    constexpr int thread_n = 2 * n_iter_cnt;
+    constexpr int cta_mma_n = n_iter_cnt * 8;
+    float acc_reg_reorg[thread_m][thread_n];
+
+    for (int i = 0; i < thread_m; i++) {
+      for (int j = 0; j < thread_n; j++) {
+        acc_reg_reorg[i][j] = acc_reg[i / 2][j / 2][(j % 2) + (i % 2) * 2];
+      }
+    }
+
+    float* smem_c = reinterpret_cast<float*>(smem_a);
+    auto smem_c_index_func = [&](int m_idx, int n_idx) {
+      int group_rows = 32 / cta_mma_n;
+      int group_cnt = 2;
+      return (m_idx % group_rows * cta_mma_n) + (m_idx / group_rows * (32 + group_cnt)) + n_idx;
+    };
+    constexpr int cosize_smem_c = ((tile_m * cta_mma_n) / 32) * (32 + 2);
+
+#pragma unroll
+    for (int m_idx_thread = 0; m_idx_thread < thread_m; m_idx_thread++) {
+#pragma unroll
+      for (int n_idx_thread = 0; n_idx_thread < thread_n; n_idx_thread++) {
+        int m_idx = (lane_idx / 4) + (m_idx_thread % 2) * 8 + (m_idx_thread / 2) * 16;
+        int n_idx = ((lane_idx % 4) * 2) + (n_idx_thread % 2) + (n_idx_thread / 2) * 8;
+        smem_c[cosize_smem_c * warp_idx + smem_c_index_func(m_idx, n_idx)] = acc_reg_reorg[m_idx_thread][n_idx_thread];
+      }
+    }
+    asm volatile("bar.sync %0, %1;" : : "r"(1), "r"(thread_cnt));
+
+    if (warp_idx == 0) {
+      constexpr int final_acc_reg_cnt = (tile_m * tile_n + 31) / 32;
+      float acc_final[final_acc_reg_cnt]{};
+
+#pragma unroll
+      for (int reg_idx = 0; reg_idx < final_acc_reg_cnt; reg_idx++) {
+        int linear_idx = reg_idx * 32 + lane_idx;
+        int m_idx = linear_idx % tile_m;
+        int n_idx = linear_idx / tile_m;
+        acc_final[reg_idx] += smem_c[smem_c_index_func(m_idx, n_idx) + 0 * cosize_smem_c] +
+                              smem_c[smem_c_index_func(m_idx, n_idx) + 1 * cosize_smem_c] +
+                              smem_c[smem_c_index_func(m_idx, n_idx) + 2 * cosize_smem_c] +
+                              smem_c[smem_c_index_func(m_idx, n_idx) + 3 * cosize_smem_c];
+      }
+
+#pragma unroll
+      for (int reg_idx = 0; reg_idx < final_acc_reg_cnt; reg_idx++) {
+        int linear_idx = reg_idx * 32 + lane_idx;
+        int m_idx = linear_idx % tile_m;
+        int n_idx = linear_idx / tile_m;
+        if (m_idx < tile_m && n_idx < gemm_n) {
+          gmem_c[n_idx * gemm_m + m_idx] = __float2bfloat16(acc_final[reg_idx]);
+        }
+      }
+    }
+#endif
+  }
+
+  bf16_t* gmem_c;
+  bf16_t* smem_a;
+  bf16_t* smem_b;
+  uint64_t* smem_barrier;
+  int warp_idx;
+  int gemm_n;
+  int stage_idx = 0;
+  int phase_bit = 0;
+  int lane_idx = threadIdx.x % 32;
+  int warp_k_offset_in_tile_k = warp_idx * per_warp_tile_k;
+
+  int a_smem_offsets[m_iter_cnt][k_phase_cnt];
+  int b_smem_offsets[n_iter_cnt][k_phase_cnt];
+
+  bf16_t a_reg[m_iter_cnt][k_phase_cnt][8];
+  bf16_t b_reg[n_iter_cnt][k_phase_cnt][4];
+  float acc_reg[m_iter_cnt][n_iter_cnt][4]{};
+};
+
+template <int batch_size, int gemm_m, int gemm_k, int tile_m, int tile_n, int tile_k, int stage_cnt>
+__global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
+    bf16_t* output, bf16_t const* mat_a, bf16_t const* mat_b, int gemm_n) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  constexpr int load_thread_cnt = 128;
+  constexpr int compute_thread_cnt = 128;
+  constexpr int thread_cnt = load_thread_cnt + compute_thread_cnt;
+  (void)thread_cnt;
+  static_assert(gemm_m % 16 == 0);
+  static_assert(gemm_k % tile_k == 0);
+  static_assert(gemm_m % tile_m == 0);
+  static_assert(tile_k == 128 || tile_k == 256 || tile_k == 512 || tile_k == 1024);
+  static_assert(tile_m == 16 || tile_m == 32);
+  constexpr int g2s_vec_bytes = 16;
+  constexpr int a_elem_bytes = 2;
+  constexpr int b_elem_bytes = 2;
+  static_assert((tile_m * a_elem_bytes + tile_n * b_elem_bytes) * tile_k * stage_cnt <= 225 * 1024);
+  static_assert((tile_m * tile_k * a_elem_bytes) % (load_thread_cnt * g2s_vec_bytes) == 0);
+  static_assert((tile_n * tile_k * b_elem_bytes) % (load_thread_cnt * g2s_vec_bytes) == 0);
+
+  extern __shared__ char smem[];
+  uint64_t* smem_barrier = reinterpret_cast<uint64_t*>(smem);
+  bf16_t* smem_a = reinterpret_cast<bf16_t*>(smem + (stage_cnt * 8 * 2 + 1024) / 1024 * 1024);
+  bf16_t* smem_b = smem_a + tile_m * tile_k * stage_cnt;
+
+  int cta_m_idx = tile_m * blockIdx.x;
+  int cta_n_idx = tile_n * blockIdx.y;
+  bf16_t const* gmem_a_local = mat_a + cta_m_idx * gemm_k;
+  bf16_t const* gmem_b_local = mat_b + cta_n_idx * gemm_k;
+  bf16_t* gmem_c_local = output + cta_n_idx * gemm_m + cta_m_idx;
+
+  int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+
+  if (warp_idx == 4) {
+    for (int i = 0; i < stage_cnt; i++) {
+      initialize_barrier(smem_barrier + i * 2 + 0, load_thread_cnt);
+      initialize_barrier(smem_barrier + i * 2 + 1, compute_thread_cnt);
+    }
+  }
+  __syncthreads();
+
+  if (warp_idx < 2) {
+    GmemLoaderA<gemm_k, tile_m, tile_k, stage_cnt> a_loader(gmem_a_local, smem_a, smem_barrier);
+    a_loader.prepare();
+    a_loader.issue_mainloop();
+  } else if (warp_idx < 4) {
+    GmemLoaderB<gemm_k, tile_n, tile_k, stage_cnt> b_loader(gmem_b_local, smem_b, smem_barrier, gemm_n);
+    b_loader.prepare();
+    b_loader.issue_mainloop();
+  } else {
+    MmaComputer<gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt> mma_computer(
+        gmem_c_local, smem_a, smem_b, smem_barrier, warp_idx, gemm_n);
+    mma_computer.prepare();
+    mma_computer.issue_mainloop();
+    mma_computer.epi();
+  }
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+constexpr int pick_tile_m(int hd_in, int hd_out) {
+  if (hd_out == 2624 && hd_in == 6144) return 32;
+  if (hd_out == 4096 && hd_in == 2048) return 32;
+  return 16;
+}
+
+template <typename T, int kHdIn, int kHdOut, int kTileN, int kTileM>
+void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens, cudaStream_t stream) {
+  constexpr int gemm_m = kHdOut;
+  int const gemm_n = num_tokens;
+  constexpr int gemm_k = kHdIn;
+  constexpr int batch_size = 1;
+  std::swap(mat_a, mat_b);
+  constexpr int tile_m = kTileM;
+  constexpr int tile_n = kTileN;
+  constexpr int tile_k = std::max(256, 1024 / tile_n);
+  constexpr int smem_stage_budget = 192 * 1024;
+  constexpr int max_stage_cnt = smem_stage_budget / ((tile_m + tile_n) * tile_k * sizeof(bf16_t));
+  constexpr int k_iter_cnt = gemm_k / tile_k;
+  constexpr int stage_cnt = k_iter_cnt > max_stage_cnt ? max_stage_cnt : k_iter_cnt;
+  int cta_m_cnt = gemm_m / tile_m;
+  int cta_n_cnt = (gemm_n + tile_n - 1) / tile_n;
+  constexpr int barrier_bytes = (stage_cnt * 16 + 1023) / 1024 * 1024;
+  constexpr int smem_bytes = ((tile_m * 2 + tile_n * 2) * tile_k * stage_cnt + barrier_bytes + 1023) / 1024 * 1024;
+
+  dim3 grid(cta_m_cnt, cta_n_cnt, 1);
+  dim3 block_size(256);
+
+  auto kernel = fused_a_gemm_kernel<batch_size, gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt>;
+  if (smem_bytes >= (48 * 1024)) {
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
+  }
+
+  cudaLaunchConfig_t config;
+  config.gridDim = grid;
+  config.blockDim = block_size;
+  config.dynamicSmemBytes = smem_bytes;
+  config.stream = stream;
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = getEnvEnablePDL();
+  config.numAttrs = 1;
+  config.attrs = attrs;
+  cudaLaunchKernelEx(&config, kernel, output, mat_a, mat_b, gemm_n);
+}
+
+}  // namespace

--- a/vllm/model_executor/kernels/fused_a_gemm/dsv3_fused_a_gemm_wrapper.cu
+++ b/vllm/model_executor/kernels/fused_a_gemm/dsv3_fused_a_gemm_wrapper.cu
@@ -1,0 +1,60 @@
+/*
+ * PyTorch extension wrapper for the JIT-compiled fused_a_gemm kernel.
+ * Included by torch.utils.cpp_extension.load at runtime.
+ *
+ * Preprocessor defines (set via -D flags during JIT compilation):
+ *   FUSED_A_GEMM_HD_IN  — input dimension (K)
+ *   FUSED_A_GEMM_HD_OUT — output dimension (N)
+ */
+
+#include "dsv3_fused_a_gemm.cuh"
+
+#include <torch/extension.h>
+#include <c10/cuda/CUDAStream.h>
+
+torch::Tensor fused_a_gemm_forward(
+    torch::Tensor mat_a,
+    torch::Tensor mat_b) {
+    TORCH_CHECK(mat_a.dim() == 2 && mat_b.dim() == 2,
+                "mat_a and mat_b must be 2D");
+    int num_tokens = mat_a.size(0);
+    TORCH_CHECK(num_tokens >= 1 && num_tokens <= 16,
+                "num_tokens must be in [1, 16], got ", num_tokens);
+
+    constexpr int kHdIn = FUSED_A_GEMM_HD_IN;
+    constexpr int kHdOut = FUSED_A_GEMM_HD_OUT;
+    TORCH_CHECK(mat_a.size(1) == kHdIn, "mat_a K dim mismatch, expected ", kHdIn,
+                " got ", mat_a.size(1));
+    TORCH_CHECK(mat_b.size(1) == kHdOut, "mat_b N dim mismatch, expected ", kHdOut,
+                " got ", mat_b.size(1));
+    TORCH_CHECK(mat_a.stride(1) == 1, "mat_a must be row-major");
+    TORCH_CHECK(mat_b.stride(0) == 1, "mat_b must be column-major");
+    TORCH_CHECK(mat_a.scalar_type() == torch::kBFloat16,
+                "mat_a must be BFloat16");
+    TORCH_CHECK(mat_b.scalar_type() == torch::kBFloat16,
+                "mat_b must be BFloat16");
+
+    auto output = torch::empty(
+        {num_tokens, kHdOut},
+        mat_a.options().dtype(torch::kBFloat16));
+
+    constexpr int kTileM = pick_tile_m(kHdIn, kHdOut);
+    auto stream = c10::cuda::getCurrentCUDAStream().stream();
+    auto* out = reinterpret_cast<bf16_t*>(output.mutable_data_ptr());
+    auto* a = reinterpret_cast<bf16_t const*>(mat_a.data_ptr());
+    auto* b = reinterpret_cast<bf16_t const*>(mat_b.data_ptr());
+
+    if (num_tokens <= 8) {
+        invokeFusedAGemm<bf16_t, kHdIn, kHdOut, 8, kTileM>(
+            out, a, b, num_tokens, stream);
+    } else {
+        invokeFusedAGemm<bf16_t, kHdIn, kHdOut, 16, kTileM>(
+            out, a, b, num_tokens, stream);
+    }
+    return output;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("fused_a_gemm_forward", &fused_a_gemm_forward,
+          "Fused A GEMM forward (JIT compiled)");
+}

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -6,7 +6,10 @@ import torch
 
 from vllm.config import CacheConfig
 from vllm.model_executor.custom_op import PluggableLayer
-from vllm.model_executor.kernels.fused_a_gemm import is_fused_a_gemm_eligible
+from vllm.model_executor.kernels.fused_a_gemm import (
+    _load_jit_module,
+    is_fused_a_gemm_eligible,
+)
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.quantization import QuantizationConfig
 
@@ -96,6 +99,11 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             and hasattr(self.q_b_proj, "weight")
             and is_fused_a_gemm_eligible(self.q_b_proj.weight)
         )
+        if self._use_fused_q_b:
+            _load_jit_module(
+                self.q_b_proj.weight.shape[1],
+                self.q_b_proj.weight.shape[0],
+            )
 
         # Whether to skip top-k token selection computation in this layer.
         # When True, the indexer will not be called, and the layer will reuse

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -6,6 +6,7 @@ import torch
 
 from vllm.config import CacheConfig
 from vllm.model_executor.custom_op import PluggableLayer
+from vllm.model_executor.kernels.fused_a_gemm import is_fused_a_gemm_eligible
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.quantization import QuantizationConfig
 
@@ -88,6 +89,14 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         self.indexer_rope_emb = mla_modules.indexer_rotary_emb
         self.is_sparse = mla_modules.is_sparse
 
+        # Check Q-B eligibility for fused_a_gemm JIT kernel
+        self._use_fused_q_b = (
+            self.q_lora_rank is not None
+            and self.q_b_proj is not None
+            and hasattr(self.q_b_proj, "weight")
+            and is_fused_a_gemm_eligible(self.q_b_proj.weight)
+        )
+
         # Whether to skip top-k token selection computation in this layer.
         # When True, the indexer will not be called, and the layer will reuse
         # the topk_tokens buffer written by a previous layer in the same pass.
@@ -166,7 +175,11 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         # Add head dim of 1 to k_pe
         k_pe = k_pe.unsqueeze(1)
 
-        q = q_proj_layer(q_proj_input)[0]
+        if self._use_fused_q_b:
+            q = torch.ops.vllm.fused_a_gemm_jit(
+                q_proj_input, self.q_b_proj.weight)
+        else:
+            q = q_proj_layer(q_proj_input)[0]
         heads = self.num_heads
         if self.dcp_q_replicate:
             heads *= q_proj_layer.group_size

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -91,6 +91,10 @@ from vllm.model_executor.models.utils import (
     extract_layer_index,
     sequence_parallel_chunk,
 )
+from vllm.model_executor.kernels.fused_a_gemm import (
+    _load_jit_module,
+    is_fused_a_gemm_eligible,
+)
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -921,26 +925,22 @@ class DeepSeekV2FusedQkvAProjLinear(MergedColumnParallelLinear):
             prefix=prefix,
         )
 
-        # Check if the DeepSeek V3 fused A GEMM kernel can be used.
+        # Check if the fused A GEMM kernel can be used.
         # This kernel supports PDL and is optimized for low batch size.
         self._use_min_latency_gemm = (
             hasattr(self, "weight")
-            and self.weight.dtype == torch.bfloat16
-            and self.weight.shape[0] == 2112
-            and self.weight.shape[1] == 7168
-            and current_platform.is_cuda()
-            and (
-                current_platform.is_device_capability(90)
-                or current_platform.is_device_capability_family(100)
-            )
+            and is_fused_a_gemm_eligible(self.weight)
         )
+        # Eagerly compile JIT module during init (before CUDA graph capture)
+        if self._use_min_latency_gemm:
+            _load_jit_module(self.weight.shape[1], self.weight.shape[0])
 
     def forward(
         self,
         input_,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.nn.Parameter | None]:
         if self._use_min_latency_gemm:
-            output = torch.ops.vllm.min_latency_fused_qkv_a_proj(input_, self.weight)
+            output = torch.ops.vllm.fused_a_gemm_jit(input_, self.weight)
             if not self.return_bias:
                 return output
             output_bias = self.bias if self.skip_bias_add else None


### PR DESCRIPTION
Autoresearch run — **post-hoc report** (regenerated from the session log; this run predates in-body reporting).

**Goal:** generalize vLLM's `fused_a_gemm` for the GLM-5.2 QKV-A + Q-B projections

**Gate:** latency
**Result:** baseline 8.860 → best 8.533 ms TPOT (3.7% faster)

```mermaid
xychart-beta
    title "tpot_ms by iteration"
    x-axis [1, 2, 3, 4, 5, 6]
    y-axis "tpot_ms"
    line [8.546166, 8.590398, 8.53309, 8.853555, 8.853555, 8.853555]
    line [8.860258, 8.860258, 8.860258, 8.860258, 8.860258, 8.860258]
```
*Per-iteration measured TPOT; the flat line is the stock baseline.*

| iter | decision | tpot_ms | note |
| --- | --- | --- | --- |
| 1 | keep | 8.546166 | latency: tpot_ms=8.546166399412414 |
| 2 | discard | 8.590398 | latency: tpot_ms=8.590398112289677 |
| 3 | keep | 8.53309 | latency: tpot_ms=8.533090294974954 |
| 4 | discard | 8.853555 | latency: tpot_ms=8.853554698021071 |
| 5 | discard | 8.853555 | latency: tpot_ms=8.853554698021071 |
| 6 | discard | 8.853555 | latency: tpot_ms=8.853554698021071 |

## Kept: iter 1

latency: tpot_ms=8.546166399412414 · diffstat: 10 files changed, 874 insertions(+), 11 deletions(-)

| rung | verdict | note |
| --- | --- | --- |
| ab-toggle | pass | ab-toggle skipped: no VLLM_GLM_TOGGLE declared |
| build | pass | candidate built |
| correctness | pass | correctness: score=0.945 |
| latency | pass | latency: tpot_ms=8.546166399412414 |
| mechanism | pass | mechanism skipped: broker has no profile tool configured |

Candidate digest: `quay.io/wseaton/vllm-candidate@sha256:685263b436680bb654e2a967ed391d325d0f62eccebf09efcadffbc539882349`

## Kept: iter 3

latency: tpot_ms=8.533090294974954 · diffstat: 3 files changed, 14 insertions(+), 6 deletions(-)

| rung | verdict | note |
| --- | --- | --- |
| ab-toggle | pass | ab-toggle skipped: no VLLM_GLM_TOGGLE declared |
| build | pass | candidate built |
| correctness | pass | correctness: score=0.925 |
| latency | pass | latency: tpot_ms=8.533090294974954 |
| mechanism | pass | mechanism skipped: broker has no profile tool configured |

Candidate digest: `quay.io/wseaton/vllm-candidate@sha256:f3db8a4efd9bc79356fc85dce23a3b0319587ce48ab829097a9103bcbb7b2715`

## Epilogue checks (advisory)

- passed — full-eval: ok (score 0.958)

Model `claude-opus-4-6` · cost $30.80 · 27973s.

🤖 opened by crucible autoresearch (draft — review and steer). Report regenerated post-hoc from the run's session log.
